### PR TITLE
fix: items with missing `lastModifiedBy`

### DIFF
--- a/src/web/open-onedrive-command.ts
+++ b/src/web/open-onedrive-command.ts
@@ -90,7 +90,7 @@ function pickFolder(
   children.then((children) => {
     const items: FolderPickItem[] = children.value.map((item) => {
       const mtime = new Date(item.lastModifiedDateTime);
-      const desc = `${item.lastModifiedBy.user.displayName} at ${dateFormat.format(mtime)}`;
+      const desc = `${item.lastModifiedBy?.user.displayName || "Unknown"} at ${dateFormat.format(mtime)}`;
       return item.folder
         ? {
             item,


### PR DESCRIPTION
Some items have a `lastModifiedDateTime`, but no `lastModifiedBy`. This causes the file picker to silently fail to load. We can show "Unknown" with the timestamp instead.